### PR TITLE
Add a configurable log level to the dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,9 @@ Now try sending a message to your dev bot in telegram and you should see it work
 
 By default, `start-dev-server` will search your current directory for functions and run a dev server for any that it finds, but you can change this by passing a specific function directory to run only that function, or a path to your project root if you're running from elsewhere.
 
-An optional second argument can be passed to change the [long poll timeout](https://core.telegram.org/bots/api#getupdates)
+An optional second argument can be passed to change the logging level. Possible values are `debug` (the default), `info`, `warn`, `error`, and `silent`
+
+An optional third argument can be passed to change the [long poll timeout](https://core.telegram.org/bots/api#getupdates)
 
 ## Using with other cloud providers (GCP, etc.)
 

--- a/test/dev-server.test.ts
+++ b/test/dev-server.test.ts
@@ -15,6 +15,7 @@ describe('dev server', () => {
     await withNockback('devServer.json', async () => {
       const server = startDevServer(
         __dirname + '/__test-project-azure__/webhook1',
+        'silent',
         1,
       )[0];
       server.stop();
@@ -28,6 +29,7 @@ describe('dev server', () => {
     await withNockback('devServer.json', async () => {
       const server = startDevServer(
         __dirname + '/__test-project-aws__/src/handlers/webhook.lambdaHandler',
+        undefined,
         1,
       )[0];
       server.stop();


### PR DESCRIPTION
- The local dev server now prints the log level before each log message in the output (e.g. using console.warn() will prefix the output with WARN)
- An optional parameter can be passed to startDevServer (or start-dev-server cli) to filter the output with a minimum log level. By default this is set to debug, i.e. no filtering