### PR TITLE
Support AWS RestApi (v1) as well as HttpApi (V2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export { Env, InlineEnv, MessageEnv } from './telegram/env';
 export { deleteWebhook, setWebhook } from './telegram/webhook-utils';
 export * from './types';
 export * as utils from './utils';
-export { wrapAzure, wrapAws, wrapTelegram };
+export { wrapAzure, wrapAws as wrapAws, wrapTelegram };
 
 // single combined wrapper for convenience
 export const createAzureTelegramWebhook = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,11 @@ import type {
   Logger as AzureLogger,
 } from '@azure/functions';
 import type {
-  APIGatewayProxyEventV2 as AwsHttpRequest,
+  APIGatewayEvent,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResult,
   APIGatewayProxyResultV2,
+  APIGatewayProxyStructuredResultV2,
   Context as AwsContext,
 } from 'aws-lambda';
 import { AppendOptions } from 'form-data';
@@ -52,7 +55,6 @@ export type {
   MessageEnv,
   Update,
   User,
-  AwsHttpRequest,
   AwsContext,
   AzureContext,
   AzureHttpRequest,
@@ -263,9 +265,10 @@ export interface AzureHttpResponse {
   headers?: Record<string, string>;
 }
 
-export type AwsHttpResponse = APIGatewayProxyResultV2<
-  Exclude<UpdateResponse, NoResponse>
->;
+export type AwsHttpRequest = APIGatewayEvent | APIGatewayProxyEventV2;
+export type AwsHttpResponse =
+  | APIGatewayProxyResult
+  | APIGatewayProxyStructuredResultV2;
 
 export type AzureHttpFunction = (
   ctx: AzureContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ import type {
   APIGatewayEvent,
   APIGatewayProxyEventV2,
   APIGatewayProxyResult,
-  APIGatewayProxyResultV2,
   APIGatewayProxyStructuredResultV2,
   Context as AwsContext,
 } from 'aws-lambda';

--- a/src/wrap-http.ts
+++ b/src/wrap-http.ts
@@ -23,7 +23,16 @@ export const wrapAzure = (
 ): AzureHttpFunction => async (ctx, { body }) =>
   (ctx.res = toHttpResponse(body && (await handler(body, ctx))));
 
+// will work with both V1 and V2 payload format versions
 export const wrapAws = (
   handler: BodyHandler<AwsContext>,
-): AwsHttpFunction => async ({ body }, ctx) =>
-  (body && (await handler(JSON.parse(body), ctx))) || '';
+): AwsHttpFunction => async ({ body }, ctx) => {
+  const response = body && (await handler(JSON.parse(body), ctx));
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: response ? JSON.stringify(response) : '',
+  };
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,14 +16,10 @@ const azureRequest = {
   },
 } as AzureHttpRequest;
 
-const awsRequest = {
-  body: JSON.stringify(azureRequest.body),
-} as AwsHttpRequest;
-
 const azureResponse = {
   body: {
-    chat_id: 1,
     method: 'sendMessage',
+    chat_id: 1,
     text: 'more good things please',
   },
   headers: {
@@ -31,7 +27,15 @@ const azureResponse = {
   },
 };
 
-const awsResponse = azureResponse.body;
+const awsRequest = {
+  body: JSON.stringify(azureRequest.body),
+} as AwsHttpRequest;
+
+const awsResponse = {
+  statusCode: 200,
+  headers: azureResponse.headers,
+  body: JSON.stringify(azureResponse.body),
+};
 
 const handler: MessageHandler = ({ text }: Message): MessageResponse => text;
 

--- a/test/telegram/webhook-utils.test.ts
+++ b/test/telegram/webhook-utils.test.ts
@@ -28,6 +28,14 @@ describe('setWebhook', () => {
     });
   });
 
+  it('throws an error if no URL is passed', () => {
+    return expect(() =>
+      setWebhook({ url: '' }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"You must provide a URL to set the webhook"`,
+    );
+  });
+
   it('throws an error if the webhook was not updated successfully', () => {
     return withNockback('setWebhook2.json', () => {
       return expect(() =>

--- a/test/wrap-http.test.ts
+++ b/test/wrap-http.test.ts
@@ -88,13 +88,24 @@ describe('wrapAzure', () => {
 describe('wrapAws', () => {
   const echo = wrapAws(async (x: any) => x);
 
-  it('parses Json', () => {
-    return expect(
-      echo({ body: JSON.stringify(jsonObj) } as any, awsCtx),
-    ).resolves.toEqual(jsonObj);
+  it('parses JSON input and stringifies JSON output', () => {
+    let body = JSON.stringify(jsonObj);
+    return expect(echo({ body } as any, awsCtx)).resolves.toEqual({
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
   });
 
-  it('ignores empty body and returns empty string instead of undefined', () => {
-    return expect(echo({} as any, awsCtx)).resolves.toEqual('');
+  it('ignores empty body in input and returns an empty body in output', () => {
+    return expect(echo({} as any, awsCtx)).resolves.toEqual({
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: '',
+    });
   });
 });


### PR DESCRIPTION
Add support for the legacy V1 payload format used by AWS RestApi endpoints, while still also supporting V2 payloads